### PR TITLE
Temporary solution to depreciated componentWillUpdate...

### DIFF
--- a/src/components/ReactMeteorData.js
+++ b/src/components/ReactMeteorData.js
@@ -16,7 +16,7 @@ const ReactMeteorData = {
     });
   },
 
-  componentWillUpdate(nextProps, nextState) {
+  UNSAFE_componentWillUpdate(nextProps, nextState) {
     if (this.startMeteorSubscriptions) {
       if (
         !EJSON.equals(this.state, nextState) ||


### PR DESCRIPTION
Using the [`UNSAFE_componentWillUpdate()`](https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate) version to [get through React v17](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path).