### PR TITLE
Add the ability to cache the whole db

### DIFF
--- a/src/Data.js
+++ b/src/Data.js
@@ -18,7 +18,7 @@ let deserializeCollection = function(db, data) {
 
 let loadDB = function (data) {
   for(let collectionName in data) {
-    let collection = Collection.deserialize(db, data[collectionName]);
+    let collection = deserializeCollection(db, data[collectionName]);
     db.collections[collectionName] = collection;
     db[collectionName] = collection;
   }

--- a/src/Data.js
+++ b/src/Data.js
@@ -8,6 +8,23 @@ const db = new minimongo();
 db.debug = false;
 db.batchedUpdates = ReactNative.unstable_batchedUpdates;
 
+let deserializeCollection = function(db, data) {
+  let collection = new Collection(data.name, db);
+  collection.items = data.items;
+  collection.versions = data.versions;
+  collection.version = data.version;
+  return collection;
+};
+
+let loadDB = function (data) {
+  for(let collectionName in data) {
+    let collection = Collection.deserialize(db, data[collectionName]);
+    db.collections[collectionName] = collection;
+    db[collectionName] = collection;
+  }
+};
+
+
 function runAfterOtherComputations(fn) {
   InteractionManager.runAfterInteractions(() => {
     Trackr.afterFlush(() => {
@@ -23,6 +40,8 @@ export default {
   subscriptions: {},
   db: db,
   calls: [],
+  
+  loadDB,
 
   getUrl() {
     return this._endpoint.substring(0, this._endpoint.indexOf('/websocket'));


### PR DESCRIPTION
This is a highly experimental trial for a way to cache and restore the whole database.

The database can be serialized and stored like this:
````
let serializedDb = Meteor.getData().db.serialize();
myStoreFunc(JSON.stringify(serializedDb));
````

And the data can be loaded like this:
````
Meteor.getData().loadDB(JSON.parse(data));
````