### PR TITLE
Cursor.Observe() 'removed' event are not firing

### DIFF
--- a/src/Collection.js
+++ b/src/Collection.js
@@ -13,15 +13,16 @@ export const runObservers = (type, collection, newDocument, oldDocument) => {
   if(observers[collection]) {
     observers[collection].forEach(({cursor, callbacks}) => {
       if(callbacks[type]) {
-        if(Data.db[collection].findOne({$and:[{_id:newDocument._id}, cursor._selector]}) && type !== 'removed') {
+        if(type === 'removed') {
+          callbacks['removed'](newDocument);
+        }
+        else if(Data.db[collection].findOne({$and:[{_id:newDocument._id}, cursor._selector]})) {
           try {
             callbacks[type](newDocument, oldDocument);
           }
           catch(e) {
             console.error("Error in observe callback", e);
           }
-        }else{
-          callbacks['removed'](newDocument);
         }
       }
     });

--- a/src/Collection.js
+++ b/src/Collection.js
@@ -13,13 +13,15 @@ export const runObservers = (type, collection, newDocument, oldDocument) => {
   if(observers[collection]) {
     observers[collection].forEach(({cursor, callbacks}) => {
       if(callbacks[type]) {
-        if(Data.db[collection].findOne({$and:[{_id:newDocument._id}, cursor._selector]})) {
+        if(Data.db[collection].findOne({$and:[{_id:newDocument._id}, cursor._selector]}) && type !== 'removed') {
           try {
             callbacks[type](newDocument, oldDocument);
           }
           catch(e) {
             console.error("Error in observe callback", e);
           }
+        }else{
+          callbacks['removed'](newDocument);
         }
       }
     });


### PR DESCRIPTION
I found that the 'removed' event in Cursor.Observe() are not firing, I guess its because 
`Data.db[collection].findOne({$and:[{_id:newDocument._id}, cursor._selector]})` returns null for deleted documents, maybe you can find a better solution than mine, thank you.